### PR TITLE
Fix mypy issues in packages using this + release 0.1.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changes
 =======
 
+0.1.1 (2024-07-05)
+------------------
+
+* Add ``py.typed`` marker file.
+* Add type annotation for ``RULE_PATHS``.
+
 0.1.0 (2024-07-04)
 ------------------
 

--- a/duplicate_url_discarder_rules/__init__.py
+++ b/duplicate_url_discarder_rules/__init__.py
@@ -6,4 +6,4 @@ _current_path = Path(__file__).parent.resolve()
 RULE_PATHS: Optional[List[str]] = glob(str(_current_path / "**/*.json"), recursive=True)
 
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/duplicate_url_discarder_rules/__init__.py
+++ b/duplicate_url_discarder_rules/__init__.py
@@ -1,8 +1,9 @@
 from glob import glob
 from pathlib import Path
+from typing import List, Optional
 
 _current_path = Path(__file__).parent.resolve()
-RULE_PATHS = glob(str(_current_path / "**/*.json"), recursive=True)
+RULE_PATHS: Optional[List[str]] = glob(str(_current_path / "**/*.json"), recursive=True)
 
 
 __version__ = "0.1.0"


### PR DESCRIPTION
An example of a downstream issue would be in https://github.com/zytedata/duplicate-url-discarder/pull/16, where it's met with:

```
mypy: commands[0]> mypy duplicate_url_discarder tests
duplicate_url_discarder/_fingerprinter.py:26: error: Skipping analyzing "duplicate_url_discarder_rules": module is installed, but missing library stubs or py.typed marker  [import-untyped]
duplicate_url_discarder/_fingerprinter.py:26: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
tests/test_fingerprinter.py:101: error: Skipping analyzing "duplicate_url_discarder_rules": module is installed, but missing library stubs or py.typed marker  [import-untyped]
```